### PR TITLE
PPI IE compatibility

### DIFF
--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -1,3 +1,4 @@
+import Set from 'core-js-pure/features/set';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import * as utils from '../../../src/utils.js';
 

--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -104,15 +104,15 @@ function validateExistingSlot(gptSlot, adUnitPath, adUnitSizes, divId) {
 
   adUnitSizes = adUnitSizes.map(size => `${size[0]}x${size[1]}`);
 
-  let difference = (listA, listB) => {
+  let hasDifference = (listA, listB) => {
     let diff = new Set(listA)
     for (let elem of listB) {
       diff.delete(elem)
     }
-    return diff
+    return diff.size;
   }
 
-  if (difference(gptSlotSizes, adUnitSizes) || difference(adUnitSizes, gptSlotSizes)) {
+  if (hasDifference(gptSlotSizes, adUnitSizes) || hasDifference(adUnitSizes, gptSlotSizes)) {
     utils.logError(`[PPI] target div '${divId}' contains slot that has different sizes than pbjs Ad Unit. Slot sizes: [${gptSlotSizes}], pbjs Ad Unit sizes: [${adUnitSizes}]. Check your pbjs Ad Unit configuration and gpt slot definition.`);
   }
 }

--- a/modules/ppi/index.js
+++ b/modules/ppi/index.js
@@ -1,3 +1,4 @@
+import Set from 'core-js-pure/features/set';
 import * as utils from '../../src/utils.js';
 import { getGlobal } from '../../src/prebidGlobal.js';
 import { hbSource } from './hbSource/hbSource.js';


### PR DESCRIPTION
Add Set polyfill to support following on IE:

```
let set = new Set(array);
```

Also, fix case where error is logged for 'mismatched' sizes between gpt slot and pbjs adUnit.