### PR TITLE
Filter most recent bids when caching is disabled

### DIFF
--- a/modules/ppi/hbDestination/callbackDestination.js
+++ b/modules/ppi/hbDestination/callbackDestination.js
@@ -1,6 +1,7 @@
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import * as utils from '../../../src/utils.js';
 import { filters } from '../../../src/targeting.js';
+import { config } from '../../../src/config.js';
 
 /** @type {Submodule}
  * Responsibility of this submodule is to provide mechanism for ppi to execute custom callback for each transactionObject
@@ -31,6 +32,13 @@ export const callbackDestinationSubmodule = {
       let bids = pbjs.getBidResponsesForAdUnitCode(matchObj.adUnit.code).bids
         .filter(filters.isUnusedBid)
         .filter(filters.isBidNotExpired);
+
+      if (bids.length && !config.getConfig('useBidCache')) {
+        // find the last auction id to get responses for the most recent auction only
+        const latestBid = bids.reduce((prev, current) => (prev.requestTimestamp > current.requestTimestamp) ? prev : current);
+        const latestAuctionId = latestBid.auctionId;
+        bids = bids.filter(bid => bid.auctionId === latestAuctionId)
+      }
 
       callback(matchObj, bids);
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Find the most recent auctionId for a given ad unit, and filter bids based on that auctionId, when bid caching is disabled.
- Applies to callback destination module which was previously always returning all available bids for a given ad unit.