### PR TITLE
Match object values

### DIFF
--- a/integrationExamples/ppi/callback.html
+++ b/integrationExamples/ppi/callback.html
@@ -1,0 +1,347 @@
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>PPI Test Page</title>
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+
+    <link rel="stylesheet" href="ppi.css">
+    <script>
+        // gpt initialization and slot definition handled by publisher
+        window.googletag = window.googletag || { cmd: [] };
+        googletag.cmd.push(() => {
+            googletag.pubads().disableInitialLoad();
+            googletag.pubads().enableSingleRequest();
+            googletag.pubads().enableAsyncRendering();
+            googletag.pubads().collapseEmptyDivs(true);
+
+            googletag.enableServices();
+
+            let adUnits = [
+                {
+                    divID: "test-1",
+                    slotId: "/19968336/header-bid-tag-0",
+                    sizes: [[300, 250], [300, 600]]
+                },
+                {
+                    divID: "test-2",
+                    slotId: "/19968336/header-bid-tag-1",
+                    sizes: [[300, 250], [300, 600]],
+                },
+                {
+                    divID: "test-3",
+                    slotId: "/19968336/header-bid-tag-0",
+                    sizes: [[300, 250], [300, 600]]
+                },
+                {
+                    divID: "test-4",
+                    slotId: "/19968336/header-bid-tag-1",
+                    sizes: [[300, 250], [300, 600]],
+                }
+            ];
+            // only store first 2 slots here
+            window.initialSlots = [];
+            for (const adunit of adUnits) {
+                let slot = googletag.defineSlot(adunit.slotId, adunit.sizes, adunit.divID).addService(googletag.pubads());
+                googletag.display(slot);
+                if (window.initialSlots.length < 2) {
+                    window.initialSlots.push(slot);
+                }
+            }
+            console.log("gpt enabled");
+        });
+    </script>
+    <script>
+        // pbjs initialization and configuration handled by publisher
+        window.pbjs = window.pbjs || { que: [] };
+        let pbjsConfig = {
+            useBidCache: true,
+            debug: true,
+            bidderTimeout: 10000,
+            rubicon: { singleRequest: true },
+            // add other prebid config here, like granularity, cmp, user syncs, bid aliases, etc.
+        }
+        window.pbjs.que.push(() => {
+            window.pbjs.ppi.addAdUnitPatterns(
+                [{
+                    slotPattern: "^.*header-bid-tag-0$",
+                    divPattern: "",
+                    code: "test-1",
+                    bids: [
+                        {
+                            bidder: 'appnexus',
+                            params: {
+                                placementId: 12224129,
+                            },
+                        },
+                        {
+                            bidder: 'adagio',
+                            params: {
+                                organizationId: '1001', // Required - Organization ID provided by Adagio.
+                                site: 'adagio-io', // Required - Site Name provided by Adagio.
+                                placement: 'in_article', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
+                                adUnitElementId: 'article_outstream', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
+                                // Optional debug mode, used to get a bid response with expected cpm.
+                                debug: {
+                                    enabled: true,
+                                    cpm: 3.00 // default to 1.00
+                                }
+                            }
+                        }],
+                    mediaTypes: {
+                        banner: {
+                            sizes: [[300, 250], [300, 600]]
+                        },
+                    },
+                }, {
+                    slotPattern: "",
+                    divPattern: "^test-.$",
+                    code: "test-2",
+                    bids: [
+                        {
+                            bidder: 'appnexus',
+                            params: {
+                                placementId: 12224129,
+                            },
+                        },
+                        {
+                            bidder: 'adagio',
+                            params: {
+                                organizationId: '1002', // Required - Organization ID provided by Adagio.
+                                site: 'adagio-io', // Required - Site Name provided by Adagio.
+                                placement: 'in_article', // Required. Refers to the placement of an adunit in a page. Must not contain any information about the type of device. Other example: `mpu_btf'.
+                                adUnitElementId: 'article_outstream', // Required - AdUnit element id. Refers to the adunit id in a page. Usually equals to the adunit code above.
+                                // Optional debug mode, used to get a bid response with expected cpm.
+                                debug: {
+                                    enabled: true,
+                                    cpm: 3.00 // default to 1.00
+                                }
+                            }
+                        }],
+                    mediaTypes: {
+                        banner: {
+                            sizes: [[300, 250], [300, 600]]
+                        },
+                    },
+                }
+                ]
+            );
+            pbjs.setConfig(pbjsConfig);
+        });
+    </script>
+    <script>
+        window.pbjs.que.push(() => {
+            window.transactionObjects = [
+                {
+                    hbInventory: {
+                        type: 'AUPSlotName',
+                        values: {
+                            name: '/19968336/header-bid-tag-0',
+                        },
+                    },
+                    hbSource: 'auction',
+                    hbDestination: {
+                        type: 'gpt',
+                        values: { div: 'test-1' }
+                    }
+                },
+                {
+                    hbInventory: {
+                        type: 'AUPDivID',
+                        values: {
+                            name: 'test-2',
+                        },
+                    },
+                    hbSource: 'auction',
+                    hbDestination: {
+                        type: 'gpt',
+                        values: { div: 'test-2' }
+                    }
+                },
+
+            ];
+            pbjs.ppi.requestBids(window.transactionObjects);
+        });
+    </script>
+
+    <script type="text/javascript" src="https://securepubads.g.doubleclick.net/tag/js/gpt.js" async></script>
+    <script async src="../../build/dev/prebid.js"></script>
+</head>
+
+<body>
+    <div class="instructions">
+        <h1> PPI Test Pages - PBJS and GPT handled by publisher </h1>
+
+        <p>
+            The following page provides an example how to use ppi only for refreshes, pbjs and gpt are handled by
+            publisher.
+            This example is mostly for publishers that are already using gpt and pbjs on their pages,
+            simplified way of refreshing adUnits.
+            Example has 3 different scripts: prebid.js embedded script that is setting pbjs config and embedded script
+            executing ppi refresh.
+            Plus there is gpt.js loaded and handled in this page, as an example of how publisher manages gpt.
+        </p>
+        <p>
+            In following example, when page is loaded, embedded script will refresh adUnits <b>test-1</b> and
+            <b>test-2</b>.
+            This means, ppi will instruct pbjs to hold HB auction for those adUnits, and then it will instruct gpt to
+            refresh appropriate slots.
+            Because gpt is handled by publisher, ppi expects that before refresh is instructed, all gpt slots are
+            already created.
+        </p>
+        <p>
+            This example has 3 buttons to test functionality.
+        <ul>
+            <li>
+                Destroy initial slots - destroys initial slots on the page ('test-1' and 'test-2'). Note: destruction is
+                needed, because this page is using test dfp account for lineitem targeting.
+                There are limited number of creatives on that account, so dfp will prevent serving ads in slots 'test-3'
+                and 'test-4' if slots 'test-1' and 'test-2' are not destroyed.
+            </li>
+            <li>
+                Fetch bids for all adUnits - clicking this button ppi will instruct pbjs to hold HB auction for all (in
+                this case 'test-1' and 'test-2') adUnits
+            </li>
+            <li>
+                Refresh from cache both adunits in divs 'test-3' and 'test-4' - clicking this button will refresh slots
+                'test-3' and 'test-4' and it will use all cached bids pbjs has
+            </li>
+        </ul>
+        </p>
+
+        <div id="console_message" class="info">
+            <p>
+                If you have not done so already, open your browser console and refresh this page.
+                Once the page is loaded you will see ads in divs 'test-1' and 'test-2'.
+                Then destroy initial slots.
+                After destroying slots you can proceed with caching bids and refreshing from cache.
+                If there are any bids in cache, refreshing from cache will cause ads to render in divs 'test-3' and
+                'test-4'.
+            </p>
+            <p>
+                You can do your own experiments in debug console with refresh logic, for example:
+                change number of adUnits for which you want to cache bids,
+                use different kind of adUnit-div remappings when rendering ads,
+                don't provide any adUnit nor any kind of remmapings to see how ppi works with default adUnits and
+                mappings,
+                etc.
+            </p>
+        </div>
+        <br><br>
+    </div>
+    <br>
+
+    <script>
+        window.transactionToCache = [
+            {
+                hbInventory: {
+                    type: 'AUPSlotName',
+                    values: {
+                        name: '/19968336/header-bid-tag-0',
+                    },
+                },
+                hbSource: 'auction',
+                sizes: [[300, 250]],
+                hbDestination: {
+                    type: 'cache',
+                }
+            },
+            {
+                hbInventory: {
+                    type: 'AUPDivID',
+                    values: {
+                        name: 'test-4',
+                    },
+                },
+                hbSource: 'auction',
+                sizes: [[300, 250]],
+                hbDestination: {
+                    type: 'cache',
+                }
+            },
+        ];
+
+        let callbacksCalled = 0;
+        let divIdAdUnitMapping = {
+            'test-3': 'test-1',
+            'test-4': 'test-2',
+        };
+        let callback = (matchObj) => {
+            callbacksCalled++;
+            let adUnitCode = matchObj.adUnit.code;
+            pbjs.setTargetingForGPTAsync([adUnitCode], (slot) => {
+                let id = slot.getSlotElementId();
+                return (code) => {
+                    return divIdAdUnitMapping[id] === code;
+                }
+            });
+
+            if (callbacksCalled === window.transactionFromCacheToCallback.length) {
+                window.googletag.pubads().refresh();
+                callbacksCalled = 0;
+            }
+        }
+        window.transactionFromCacheToCallback = [
+            {
+                hbInventory: {
+                    type: 'AUPSlotName',
+                    values: {
+                        name: '/19968336/header-bid-tag-0',
+                    },
+                },
+                hbSource: 'cache',
+                sizes: [[300, 600]],
+                hbDestination: {
+                    type: 'callback',
+                    values: { callback: callback }
+                }
+            },
+            {
+                hbInventory: {
+                    type: 'AUPDivID',
+                    values: {
+                        name: 'test-4',
+                    },
+                },
+                hbSource: 'cache',
+                sizes: [[300, 600]],
+                hbDestination: {
+                    type: 'callback',
+                    values: { callback: callback }
+                }
+            },
+        ];
+
+        window.autoSlots = [
+            {
+                hbInventory: {
+                    type: 'AUPAutoSlots',
+                },
+                hbSource: 'auction',
+                hbDestination: {
+                    type: 'gpt',
+                }
+            }
+        ];
+    </script>
+    <button onclick='googletag.destroySlots(window.initialSlots)'>Destroy initial slots</button>
+    <button onclick='pbjs.ppi.requestBids(window.transactionToCache)'>Fetch bids for both adunits</button>
+    <button onclick='pbjs.ppi.requestBids(window.transactionFromCacheToCallback)'>Using callback refresh
+        from cache both adunits in divs 'test-3' and 'test-4'</button>
+    <button onclick='pbjs.ppi.requestBids(window.autoSlots)'>refresh autoslots</button>
+
+    <div id="test-1" class="adunit"></div>
+    <div id="test-2" class="adunit"></div>
+    <div id="test-3" class="adunit"></div>
+    <div id="test-4" class="adunit"></div>
+    <br />
+    <br />
+    <br />
+</body>
+
+</html>

--- a/modules/ppi/hbDestination/callbackDestination.js
+++ b/modules/ppi/hbDestination/callbackDestination.js
@@ -1,7 +1,4 @@
-import { getGlobal } from '../../../src/prebidGlobal.js';
 import * as utils from '../../../src/utils.js';
-import { filters } from '../../../src/targeting.js';
-import { config } from '../../../src/config.js';
 
 /** @type {Submodule}
  * Responsibility of this submodule is to provide mechanism for ppi to execute custom callback for each transactionObject
@@ -16,31 +13,18 @@ export const callbackDestinationSubmodule = {
    * @param {function} callback
    */
   send(matchObjects) {
-    let pbjs = getGlobal();
     matchObjects.forEach(matchObj => {
       let callback = utils.deepAccess(matchObj, 'transactionObject.hbDestination.values.callback');
       if (!utils.isFn(callback)) {
         utils.logError('[PPI] Callback is not a function ', callback);
         return;
       }
+
       if (!matchObj.adUnit) {
         utils.logWarn('[PPI] adUnit not created for transaction object ', matchObj.transactionObject);
-        utils.logWarn('[PPI] executing callback without bids');
-        callback(matchObj);
-        return;
-      }
-      let bids = pbjs.getBidResponsesForAdUnitCode(matchObj.adUnit.code).bids
-        .filter(filters.isUnusedBid)
-        .filter(filters.isBidNotExpired);
-
-      if (bids.length && !config.getConfig('useBidCache')) {
-        // find the last auction id to get responses for the most recent auction only
-        const latestBid = bids.reduce((prev, current) => (prev.requestTimestamp > current.requestTimestamp) ? prev : current);
-        const latestAuctionId = latestBid.auctionId;
-        bids = bids.filter(bid => bid.auctionId === latestAuctionId)
       }
 
-      callback(matchObj, bids);
+      callback(matchObj);
     });
   },
 };

--- a/modules/ppi/hbSource/auctionSource.js
+++ b/modules/ppi/hbSource/auctionSource.js
@@ -1,5 +1,8 @@
 import * as utils from '../../../src/utils.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
+import { filters } from '../../../src/targeting.js';
+import { config } from '../../../src/config.js';
+import { auctionTracker } from './auctionTracker.js';
 
 /** @type {Submodule}
  * Responsibility of this submodule is to provide mechanism for ppi to requestBids from new HB auction
@@ -16,10 +19,35 @@ export const auctionSourceSubmodule = {
   requestBids(matchObjects, callback) {
     utils.logInfo('[PPI] Triggering new HB auction');
 
-    getGlobal().requestBids({
+    let pbjs = getGlobal();
+    pbjs.requestBids({
       adUnits: matchObjects.filter(mo => mo.adUnit).map(mo => mo.adUnit),
-      bidsBackHandler: (bids) => {
+      bidsBackHandler: (bids, timedOut, auctionId) => {
         utils.logInfo('[PPI] - bids from bidsBackHandler: ', bids);
+
+        // add matchObject.values and log the latest auction
+        matchObjects.forEach(mo => {
+          if (!mo.adUnit) {
+            return;
+          }
+
+          let auBids = bids && bids[mo.adUnit.code] && bids[mo.adUnit.code].bids;
+          auctionTracker.setLatestAuction(mo.adUnit.code, auBids, timedOut, auctionId);
+
+          // if bid caching is enabled, attach all bids
+          if (config.getConfig('useBidCache')) {
+            auBids = pbjs.getBidResponsesForAdUnitCode(mo.adUnit.code).bids
+              .filter(filters.isUnusedBid)
+              .filter(filters.isBidNotExpired);
+          }
+
+          mo.values = {
+            bids: auBids,
+            timedOut: timedOut,
+            auctionId: auctionId,
+          };
+        });
+
         if (utils.isFn(callback)) {
           callback(matchObjects);
         }

--- a/modules/ppi/hbSource/auctionTracker.js
+++ b/modules/ppi/hbSource/auctionTracker.js
@@ -1,0 +1,19 @@
+/**
+ * This object holds all the latest auction information for each adUnit
+ */
+export const auctionTracker = {
+  // adUnitCode -> {bids, timedOut, auctionId}
+  latestAuctionForAdUnit: {},
+
+  setLatestAuction(adUnitCode, bids, timedOut, auctionId) {
+    this.latestAuctionForAdUnit[adUnitCode] = {
+      bids: bids,
+      timedOut: timedOut,
+      auctionId,
+    };
+  },
+
+  getLatestAuction(adUnitCode) {
+    return this.latestAuctionForAdUnit[adUnitCode];
+  }
+};

--- a/modules/ppi/hbSource/cacheSource.js
+++ b/modules/ppi/hbSource/cacheSource.js
@@ -19,7 +19,7 @@ export const cacheSourceSubmodule = {
   requestBids(matchObjects, callback) {
     let cachingEnabled = config.getConfig('useBidCache');
     if (!cachingEnabled) {
-      utils.logError('[PPI] Enable bid caching (useBidCache: true) to use the cache source module!');
+      utils.logWarn('[PPI] Enable bid caching (useBidCache: true) to use the cache source module!');
     }
 
     utils.logInfo('[PPI] Using bids from bid cache');

--- a/modules/ppi/hbSource/cacheSource.js
+++ b/modules/ppi/hbSource/cacheSource.js
@@ -1,6 +1,8 @@
 import * as utils from '../../../src/utils.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import { filters } from '../../../src/targeting.js';
+import { config } from '../../../src/config.js';
+import { auctionTracker } from './auctionTracker.js';
 
 /** @type {Submodule}
  * Responsibility of this submodule is to provide mechanism for ppi to requestBids from cache
@@ -15,6 +17,11 @@ export const cacheSourceSubmodule = {
    * @param {function} callback
    */
   requestBids(matchObjects, callback) {
+    let cachingEnabled = config.getConfig('useBidCache');
+    if (!cachingEnabled) {
+      utils.logError('[PPI] Enable bid caching (useBidCache: true) to use the cache source module!');
+    }
+
     utils.logInfo('[PPI] Using bids from bid cache');
     // store match objects that don't have any bids and trigger new HB auction
     let emptyCacheMatches = [];
@@ -44,6 +51,12 @@ export const cacheSourceSubmodule = {
         return;
       }
 
+      matchObj.values = auctionTracker.getLatestAuction(matchObj.adUnit.code) || {};
+      if (cachingEnabled) {
+        // attach all bids from bid cache
+        matchObj.values.bids = bids;
+      }
+
       readyMatches.push(matchObj);
     });
 
@@ -55,8 +68,27 @@ export const cacheSourceSubmodule = {
     if (emptyCacheMatches.length) {
       pbjs.requestBids({
         adUnits: emptyCacheMatches.filter(mo => mo.adUnit).map(mo => mo.adUnit),
-        bidsBackHandler: (bids) => {
+        bidsBackHandler: (bids, timedOut, auctionId) => {
           utils.logInfo('[PPI] - bids from bidsBackHandler: ', bids);
+
+          // add matchObject.values and log the latest auction
+          emptyCacheMatches.forEach(mo => {
+            if (!mo.adUnit) {
+              return;
+            }
+
+            let auBids = bids && bids[mo.adUnit.code] && bids[mo.adUnit.code].bids;
+            if (cacheSourceSubmodule.auctionTracker) {
+              cacheSourceSubmodule.auctionTracker.setLatestAuction(mo.adUnit.code, auBids, timedOut, auctionId);
+            }
+
+            mo.values = {
+              bids: auBids,
+              timedOut: timedOut,
+              auctionId: auctionId,
+            };
+          });
+
           if (utils.isFn(callback)) {
             callback(emptyCacheMatches);
           }

--- a/modules/ppi/hbSource/cacheSource.js
+++ b/modules/ppi/hbSource/cacheSource.js
@@ -73,14 +73,8 @@ export const cacheSourceSubmodule = {
 
           // add matchObject.values and log the latest auction
           emptyCacheMatches.forEach(mo => {
-            if (!mo.adUnit) {
-              return;
-            }
-
             let auBids = bids && bids[mo.adUnit.code] && bids[mo.adUnit.code].bids;
-            if (cacheSourceSubmodule.auctionTracker) {
-              cacheSourceSubmodule.auctionTracker.setLatestAuction(mo.adUnit.code, auBids, timedOut, auctionId);
-            }
+            auctionTracker.setLatestAuction(mo.adUnit.code, auBids, timedOut, auctionId);
 
             mo.values = {
               bids: auBids,

--- a/modules/ppi/hbSource/hbSource.js
+++ b/modules/ppi/hbSource/hbSource.js
@@ -5,5 +5,6 @@ import { cacheSourceSubmodule } from './cacheSource.js';
  * This object holds all available hbSource submodules, currently only 'auction' and 'cache' are available
  */
 export const hbSource = {};
+
 hbSource[auctionSourceSubmodule.name] = auctionSourceSubmodule;
 hbSource[cacheSourceSubmodule.name] = cacheSourceSubmodule;

--- a/test/spec/modules/hbDestination_spec.js
+++ b/test/spec/modules/hbDestination_spec.js
@@ -132,36 +132,29 @@ describe('test ppi hbDestination submodule', () => {
   });
 
   it('callback destination should process result', () => {
-    sandbox.stub($$PREBID_GLOBAL$$, 'getBidResponsesForAdUnitCode').callsFake((key) => {
-      return { bids: adUnitBids[key] || [] };
-    });
-
     let match = utils.deepClone(matches);
     match[0].transactionObject.hbDestination = {
       type: 'callback',
       values: {
-        callback: (matchObj, bids) => {
+        callback: (matchObj) => {
           expect(matchObj).to.equal(match[0]);
-          expect(bids).to.be.a('undefined');
+          expect(matchObj.values).to.be.a('undefined');
         }
       }
     };
     match[1].transactionObject.hbDestination = {
       type: 'callback',
       values: {
-        callback: (matchObj, bids) => {
+        callback: (matchObj) => {
           expect(matchObj).to.equal(match[1]);
-          expect(bids.length).to.equal(1);
-          expect(bids[0].cpm).to.equal(1.69);
         }
       }
     };
     match[2].transactionObject.hbDestination = {
       type: 'callback',
       values: {
-        callback: (matchObj, bids) => {
+        callback: (matchObj) => {
           expect(matchObj).to.equal(match[2]);
-          expect(bids).to.deep.equal([]);
         }
       }
     };

--- a/test/spec/modules/hbSource_spec.js
+++ b/test/spec/modules/hbSource_spec.js
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
 import { hbSource } from 'modules/ppi/hbSource/hbSource.js';
+import { config as configObj } from 'src/config.js';
 
 describe('test ppi hbSource submodule', () => {
   let sandbox;
   beforeEach(() => {
+    configObj.setConfig({ useBidCache: false });
     sandbox = sinon.sandbox.create();
   });
 
@@ -70,5 +72,213 @@ describe('test ppi hbSource submodule', () => {
 
     expect(bidsRequested).to.equal(true);
     expect(cacheCallbackCalled).to.equal(true);
+  });
+
+  it('should attach values to matchObject', () => {
+    const adUnitBids = {
+      'test-1': {
+        bids: [{
+          responseTimestamp: new Date().getTime(),
+          ttl: 1000,
+          cpm: 1.12,
+          status: 'available',
+          adUnitCode: 'test-1',
+          auctionId: '1234-56789-0000',
+        }]
+      }
+    };
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'requestBids').callsFake(({ bidsBackHandler }) => {
+      bidsBackHandler(adUnitBids, false, '1234-56789-0000');
+    });
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'getBidResponsesForAdUnitCode').callsFake((code) => {
+      return adUnitBids[code];
+    });
+
+    let matches = [{ adUnit: { code: 'test-1' } }];
+
+    let destMos;
+    hbSource['auction'].requestBids(matches, (mos) => {
+      destMos = mos;
+    });
+
+    expect(destMos.length).to.equal(1);
+    expect(destMos[0].values).to.not.be.undefined;
+    expect(destMos[0].values.auctionId).to.equal('1234-56789-0000');
+    expect(destMos[0].values.timedOut).to.be.false;
+    expect(destMos[0].values.bids).to.equal(adUnitBids['test-1'].bids);
+  });
+
+  it('should attach all bids to match object', () => {
+    configObj.setConfig({ useBidCache: true });
+    const latestBid = {
+      responseTimestamp: new Date().getTime(),
+      ttl: 1000,
+      cpm: 1.12,
+      status: 'available',
+      adUnitCode: 'test-1',
+      auctionId: '1234-56789-0001',
+    };
+
+    const adUnitBids = {
+      'test-1': {
+        bids: [{
+          responseTimestamp: new Date().getTime(),
+          ttl: 1000,
+          cpm: 0.12,
+          status: 'available',
+          adUnitCode: 'test-1',
+          auctionId: '1234-56789-0000',
+        }, latestBid]
+      }
+    };
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'requestBids').callsFake(({ bidsBackHandler }) => {
+      bidsBackHandler({
+        'test-1': {
+          bids: [latestBid]
+        }
+      }, true, '1234-56789-0001');
+    });
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'getBidResponsesForAdUnitCode').callsFake((code) => {
+      return adUnitBids[code];
+    });
+
+    let matches = [{ adUnit: { code: 'test-1' } }];
+
+    let destMos;
+    hbSource['auction'].requestBids(matches, (mos) => {
+      destMos = mos;
+    });
+
+    expect(destMos.length).to.equal(1);
+    expect(destMos[0].values).to.not.be.undefined;
+    expect(destMos[0].values.auctionId).to.equal('1234-56789-0001');
+    expect(destMos[0].values.timedOut).to.be.true;
+    expect(destMos[0].values.bids.length).to.equal(2);
+    expect(destMos[0].values.bids[0]).to.equal(adUnitBids['test-1'].bids[0]);
+    expect(destMos[0].values.bids[1]).to.equal(adUnitBids['test-1'].bids[1]);
+  });
+
+  it('should attach only latest bid to match object', () => {
+    const latestBid = {
+      responseTimestamp: new Date().getTime(),
+      ttl: 1000,
+      cpm: 1.12,
+      status: 'available',
+      adUnitCode: 'test-1',
+      auctionId: '1234-56789-0001',
+    };
+
+    const adUnitBids = {
+      'test-1': {
+        bids: [{
+          responseTimestamp: new Date().getTime(),
+          ttl: 1000,
+          cpm: 0.12,
+          status: 'available',
+          adUnitCode: 'test-1',
+          auctionId: '1234-56789-0000',
+        }, latestBid]
+      }
+    };
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'requestBids').callsFake(({ bidsBackHandler }) => {
+      bidsBackHandler({
+        'test-1': {
+          bids: [latestBid]
+        }
+      }, true, '1234-56789-0001');
+    });
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'getBidResponsesForAdUnitCode').callsFake((code) => {
+      return adUnitBids[code];
+    });
+
+    let matches = [{ adUnit: { code: 'test-1' } }];
+
+    let destMos;
+    hbSource['auction'].requestBids(matches, (mos) => {
+      destMos = mos;
+    });
+
+    expect(destMos.length).to.equal(1);
+    expect(destMos[0].values).to.not.be.undefined;
+    expect(destMos[0].values.auctionId).to.equal('1234-56789-0001');
+    expect(destMos[0].values.timedOut).to.be.true;
+    expect(destMos[0].values.bids.length).to.equal(1);
+    expect(destMos[0].values.bids[0]).to.equal(latestBid);
+  });
+
+  it('should not attach values to match object when no ad unit got matched', () => {
+    let destMos;
+    hbSource['cache'].requestBids([{ transcactionObject: {}, adUnit: undefined }], (mos) => {
+      destMos = mos;
+    });
+
+    expect(destMos.length).to.equal(1);
+    expect(destMos[0].values).to.be.undefined;
+  });
+
+  it('should reauction units without bids', () => {
+    configObj.setConfig({ useBidCache: true });
+    const latestBid = {
+      responseTimestamp: new Date().getTime(),
+      ttl: 1000,
+      cpm: 1.12,
+      status: 'available',
+      adUnitCode: 'test-2',
+      auctionId: '1234-56789-0001',
+    };
+
+    const adUnitBids = {
+      'test-1': {
+        bids: [{
+          responseTimestamp: new Date().getTime(),
+          ttl: 1000,
+          cpm: 0.12,
+          status: 'available',
+          adUnitCode: 'test-1',
+          auctionId: '1234-56789-0000',
+        }]
+      }
+    };
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'requestBids').callsFake(({ adUnits, bidsBackHandler }) => {
+      if (adUnits.length != 1 || adUnits[0].code != 'test-2') {
+        expect.fail('request bids should be called only for test-2 adUnit');
+      }
+
+      bidsBackHandler({
+        'test-2': {
+          bids: [latestBid]
+        }
+      }, true, '1234-56789-0001');
+    });
+
+    sandbox.stub($$PREBID_GLOBAL$$, 'getBidResponsesForAdUnitCode').callsFake((code) => {
+      return adUnitBids[code];
+    });
+
+    let matches = [
+      { transactionObject: {}, adUnit: { code: 'test-1' } },
+      { transactionObject: {}, adUnit: { code: 'test-2' } },
+      { transactionObject: {}, adUnit: undefined }
+    ];
+
+    let destMos = [];
+    let destCalled = 0;
+    hbSource['cache'].requestBids(matches, (mos) => {
+      destCalled++;
+      destMos = destMos.concat(mos);
+    });
+
+    expect(destCalled).to.equal(2);
+    expect(destMos.length).to.equal(3);
+    expect(destMos.some(mo => mo.adUnit == undefined)).to.be.true;
+    expect(destMos.some(mo => mo.adUnit && mo.adUnit.code == 'test-1' && mo.values.bids[0].auctionId == '1234-56789-0000')).to.be.true;
+    expect(destMos.some(mo => mo.adUnit && mo.adUnit.code == 'test-2' && mo.values.auctionId == '1234-56789-0001')).to.be.true;
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Add `values` to matchObject, that is being passed from hbSource to hbDestination.
- For now, `values` includes bids, timedOut and auctionId, properties available through bidsBackHandler.
- matchObject.values will always exist in the destination module, when matchObject.adUnit exists, otherwise it will be undefined (no values for unmatched transaction objects).
- In case bid caching is enabled, matchObject.values.bids will include all unused bids, not only bids from the last auction.
- Code that was doing bid filtering (based on bid caching enabled/disabled)  inside callback destination module is now moved to hbSource modules, where we add them to matchObject.values.
- Increase test coverage for hbSource modules.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
