### PR TITLE
Allow size overrides for slot_object transaction type

### DIFF
--- a/modules/ppi/hbInventory/aup/sizes.js
+++ b/modules/ppi/hbInventory/aup/sizes.js
@@ -29,11 +29,12 @@ export function findAUPSizes(aup) {
 export function findLimitSizes(transactionObject) {
   let toSizes = transactionObject.hbInventory.sizes;
   if (transactionObject.hbInventory.type === TransactionType.SLOT_OBJECT) {
-    if (toSizes && toSizes.length) {
-      utils.logWarn(`hbInventory.sizes override is not supported for transaction type ${transactionObject.hbInventory.type}`);
+    let gptSizes = getGptSlotSizes(transactionObject.hbInventory.values.slot);
+    if (!toSizes || !toSizes.length) {
+      return gptSizes
     }
 
-    return getGptSlotSizes(transactionObject.hbInventory.values.slot);
+    utils.logWarn(`slot defined with sizes: ${gptSizes}. Using sizes override: ${toSizes}`);
   }
 
   return toSizes;

--- a/test/spec/modules/aup_spec.js
+++ b/test/spec/modules/aup_spec.js
@@ -248,7 +248,7 @@ describe('add adUnitPattern', () => {
       ],
       mediaTypes: {
         banner: {
-          sizes: [[1, 1]]
+          sizes: [[1, 1], [3, 3]]
         },
       },
     },
@@ -369,10 +369,13 @@ describe('add adUnitPattern', () => {
     let gptSlotSizes = [[1, 1], [2, 2]];
     let gptSlot = makeGPTSlot('/19968336/header-bid-tag-1', 'test-3', gptSlotSizes);
 
+    let sizesOverride = [[3, 3], [2, 2], [1, 1]];
+
     let tos = [
       {
         hbInventory: {
           type: TransactionType.DIV,
+          sizes: sizesOverride,
           values: {
             name: 'test-1',
           }
@@ -386,12 +389,12 @@ describe('add adUnitPattern', () => {
       {
         hbInventory: {
           type: TransactionType.SLOT,
+          sizes: sizesOverride,
           values: {
             name: '/19968336/header-bid-tag-0',
           }
         },
         hbSource: 'auction',
-        sizes: [[1, 1]],
         hbDestination: {
           type: 'gpt',
           values: { div: 'test-2' }
@@ -400,6 +403,7 @@ describe('add adUnitPattern', () => {
       {
         hbInventory: {
           type: TransactionType.SLOT_OBJECT,
+          sizes: sizesOverride,
           values: {
             slot: gptSlot,
           }
@@ -418,6 +422,9 @@ describe('add adUnitPattern', () => {
     expect(result[0].adUnit.code).to.equal('pattern-1');
     expect(result[1].adUnit.code).to.equal('pattern-2');
     expect(result[2].adUnit.code).to.be.a('string');
+    expect(result[0].adUnit.mediaTypes.banner.sizes).to.deep.equal(sizesOverride);
+    expect(result[1].adUnit.mediaTypes.banner.sizes).to.deep.equal(sizesOverride);
+    expect(result[2].adUnit.mediaTypes.banner.sizes).to.deep.equal([[3, 3], [1, 1]]);
   });
 
   describe('create adUnit', () => {


### PR DESCRIPTION
Allow size overrides for transaction type: `AUPSlotObject`.