### PR TITLE
PPI additional info logging

### DIFF
--- a/modules/ppi/hbInventory/aup/aup.js
+++ b/modules/ppi/hbInventory/aup/aup.js
@@ -156,10 +156,11 @@ export function matchAUPs(transactionObjects, adUnitPatterns) {
         break;
       case 1:
         aup = aups[0];
+        utils.logInfo('[PPI] Transaction object', to, 'matched AUP', aup);
         lock.add(aup);
         break;
       default:
-        utils.logWarn('[PPI] More than one AUP matched, for transaction object. Will take the first one', to, aups);
+        utils.logWarn('[PPI] More than one AUP matched, for transaction object', to, 'Taking the first one', aups);
         aup = aups[0];
         lock.add(aup);
         break;

--- a/modules/ppi/index.js
+++ b/modules/ppi/index.js
@@ -20,6 +20,7 @@ let inventoryRegistry = hbInventory;
  * @return {(Object[])} array of transactionObjects and matched adUnits
  */
 export function requestBids(transactionObjects) {
+  utils.logInfo('[PPI] requestBids, transaction objects', transactionObjects);
   let validationResult = validateTransactionObjects(transactionObjects);
   let transactionResult = [];
   validationResult.invalid.forEach(inv => {
@@ -34,6 +35,7 @@ export function requestBids(transactionObjects) {
     for (const dest in groupedTransactionObjects[source]) {
       let matchObjects = inventoryRegistry.createAdUnits(groupedTransactionObjects[source][dest]);
       sourceRegistry[source].requestBids(matchObjects, (matches) => {
+        utils.logInfo('[PPI] calling destination module [' + dest + '] from source [' + source + ']');
         destinationRegistry[dest].send(matches);
       });
 
@@ -46,6 +48,7 @@ export function requestBids(transactionObjects) {
     }
   }
 
+  utils.logInfo('[PPI] requestBids, transaction result', transactionResult);
   return transactionResult;
 }
 


### PR DESCRIPTION
- [x] Other

## Description of change
Add informational logging to track transaction objects and matched AUPs.
