### PR TITLE
PPI fpd

### DIFF
--- a/modules/ppi/hbInventory/aup/aup.js
+++ b/modules/ppi/hbInventory/aup/aup.js
@@ -346,6 +346,7 @@ export function applyFirstPartyData(adUnit, adUnitPattern, transactionObject) {
     adUnit.ortb2Imp = transactionObject.hbInventory.ortb2Imp;
   }
 
+  utils.deepSetValue(adUnit, 'ortb2Imp.ext.data.ppi.source', transactionObject.hbSource.type);
   utils.deepSetValue(adUnit, 'ortb2Imp.ext.data.ppi.destination', transactionObject.hbDestination.type);
 
   let elementId = utils.deepAccess(transactionObject, 'hbDestination.values.div') || getDivId(transactionObject, adUnitPattern);

--- a/modules/ppi/hbInventory/aup/aup.js
+++ b/modules/ppi/hbInventory/aup/aup.js
@@ -346,6 +346,13 @@ export function applyFirstPartyData(adUnit, adUnitPattern, transactionObject) {
     adUnit.ortb2Imp = transactionObject.hbInventory.ortb2Imp;
   }
 
+  utils.deepSetValue(adUnit, 'ortb2Imp.ext.data.ppi.destination', transactionObject.hbDestination.type);
+
+  let elementId = utils.deepAccess(transactionObject, 'hbDestination.values.div') || getDivId(transactionObject, adUnitPattern);
+  if (elementId) {
+    utils.deepSetValue(adUnit, 'ortb2Imp.ext.data.elementid', elementId);
+  }
+
   let slotName = getSlotName(transactionObject, adUnitPattern);
   if (!slotName) {
     return;

--- a/test/spec/modules/ppi_spec.js
+++ b/test/spec/modules/ppi_spec.js
@@ -301,6 +301,8 @@ describe('ppiTest', () => {
       tos[2].hbDestination.type = 'gpt';
 
       let res = ppi.requestBids(transactionObjects);
+      expect(res[0].adUnit.ortb2Imp.ext.data.ppi.source).to.equal('auction');
+      expect(res[2].adUnit.ortb2Imp.ext.data.ppi.source).to.equal('cache');
       expect(res[0].adUnit.ortb2Imp.ext.data.ppi.destination).to.equal('page');
       expect(res[2].adUnit.ortb2Imp.ext.data.ppi.destination).to.equal('gpt');
       expect(res[0].adUnit.ortb2Imp.ext.data.elementid).to.equal('test-1');

--- a/test/spec/modules/ppi_spec.js
+++ b/test/spec/modules/ppi_spec.js
@@ -290,5 +290,21 @@ describe('ppiTest', () => {
       expect(res[2].adUnit.code).to.equal('pattern-2');
       expect(newAuctionHeld).to.equal(true);
     });
+
+    it('should add PPI fpd', () => {
+      sandbox.stub($$PREBID_GLOBAL$$, 'requestBids').callsFake(({ bidsBackHandler }) => {
+        bidsBackHandler();
+      });
+
+      let tos = utils.deepClone(transactionObjects);
+      tos[0].hbSource.type = 'auction';
+      tos[2].hbDestination.type = 'gpt';
+
+      let res = ppi.requestBids(transactionObjects);
+      expect(res[0].adUnit.ortb2Imp.ext.data.ppi.destination).to.equal('page');
+      expect(res[2].adUnit.ortb2Imp.ext.data.ppi.destination).to.equal('gpt');
+      expect(res[0].adUnit.ortb2Imp.ext.data.elementid).to.equal('test-1');
+      expect(res[2].adUnit.ortb2Imp.ext.data.elementid).to.equal('test-5');
+    });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change

- Adding `ortb2Imp.ext.data.ppi.destination` to signal analytics adapters (or other interested parties) about the expected outcome of the PPI transaction.
- Adding `ortb2Imp.ext.data.elementid` to signal target Div Id - when applicable.

## Other information

- Note that rubicon bid adapter is filtering out `.data.ppi.` fpd at the moment.
![Screenshot from 2021-09-09 10-40-01](https://user-images.githubusercontent.com/12955750/132653318-9b41534e-7f46-4225-ab2a-4ed67b4a1e8c.png)