### PR TITLE
Amazon support

### DIFF
--- a/integrationExamples/ppi/callback.html
+++ b/integrationExamples/ppi/callback.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
         integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 
-    <link rel="stylesheet" href="ppi.css">
     <script>
         // gpt initialization and slot definition handled by publisher
         window.googletag = window.googletag || { cmd: [] };

--- a/integrationExamples/ppi/ppi.html
+++ b/integrationExamples/ppi/ppi.html
@@ -10,7 +10,6 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
         integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 
-    <link rel="stylesheet" href="ppi.css">
     <script>
         // gpt initialization and slot definition handled by publisher
         window.googletag = window.googletag || { cmd: [] };

--- a/integrationExamples/ppi/ppi.html
+++ b/integrationExamples/ppi/ppi.html
@@ -133,6 +133,9 @@
                         },
                         hbSource: {
                             type: 'auction',
+                            values: {
+                                amazonEnabled: true,
+                            }
                         },
                         hbDestination: {
                             type: 'gpt',
@@ -148,6 +151,9 @@
                         },
                         hbSource: {
                             type: 'auction',
+                            values: {
+                                amazonEnabled: true,
+                            }
                         },
                         hbDestination: {
                             type: 'gpt',
@@ -162,6 +168,18 @@
     </script>
 
     <script type="text/javascript" src="https://securepubads.g.doubleclick.net/tag/js/gpt.js" async></script>
+    <script src="https://c.amazon-adsystem.com/aax2/apstag.js"></script>
+    <script>
+        let amazonConfig = {
+            adServer: "googletag",
+            bidTimeout: 5000,
+            gdpr: { cmpTimeout: 16000 },
+            params: {},
+            pubID: "1",
+        }
+
+        window.apstag.init(amazonConfig);
+    </script>
     <script async src="../../build/dev/prebid.js"></script>
 </head>
 

--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -75,9 +75,7 @@ export const gptDestinationSubmodule = {
         adUnitCodes.push(code);
 
         mappings[code] = divId;
-        if (!hasAmazonEnabled && utils.deepAccess(matchObj.transactionObject, 'hbSource.amazonEnabled')) {
-          hasAmazonEnabled = true;
-        }
+        hasAmazonEnabled = hasAmazonEnabled || utils.deepAccess(matchObj.transactionObject, 'hbSource.amazonEnabled');
       });
       setTargeting(adUnitCodes, mappings);
       if (hasAmazonEnabled) {

--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -1,6 +1,7 @@
 import Set from 'core-js-pure/features/set';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import * as utils from '../../../src/utils.js';
+import { setTargeting as setAmazonTargeting } from '../../ppi/hbSource/amazonSource.js';
 
 window.googletag = window.googletag || {};
 window.googletag.cmd = window.googletag.cmd || [];
@@ -28,6 +29,7 @@ export const gptDestinationSubmodule = {
       let gptSlotsToRefresh = [];
       let adUnitCodes = [];
       let mappings = {};
+      let hasAmazonEnabled = false;
       matchObjects.forEach(matchObj => {
         matchObj.transactionObject.hbDestination.values = matchObj.transactionObject.hbDestination.values || {};
         let divId = matchObj.transactionObject.hbDestination.values.div || matchObj.transactionObject.divId;
@@ -73,8 +75,14 @@ export const gptDestinationSubmodule = {
         adUnitCodes.push(code);
 
         mappings[code] = divId;
+        if (!hasAmazonEnabled && utils.deepAccess(matchObj.transactionObject, 'hbSource.amazonEnabled')) {
+          hasAmazonEnabled = true;
+        }
       });
       setTargeting(adUnitCodes, mappings);
+      if (hasAmazonEnabled) {
+        setAmazonTargeting();
+      }
       window.googletag.pubads().refresh(gptSlotsToRefresh);
     });
   },
@@ -117,7 +125,7 @@ function validateExistingSlot(gptSlot, adUnitPath, adUnitSizes, divId) {
   }
 }
 
-function getDivIdGPTSlotMapping() {
+export function getDivIdGPTSlotMapping() {
   let mappings = {};
   window.googletag.pubads().getSlots().forEach(slot => {
     mappings[slot.getSlotElementId()] = slot;

--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -123,7 +123,7 @@ function validateExistingSlot(gptSlot, adUnitPath, adUnitSizes, divId) {
   }
 }
 
-export function getDivIdGPTSlotMapping() {
+function getDivIdGPTSlotMapping() {
   let mappings = {};
   window.googletag.pubads().getSlots().forEach(slot => {
     mappings[slot.getSlotElementId()] = slot;

--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -75,7 +75,7 @@ export const gptDestinationSubmodule = {
         adUnitCodes.push(code);
 
         mappings[code] = divId;
-        hasAmazonEnabled = hasAmazonEnabled || utils.deepAccess(matchObj.transactionObject, 'hbSource.amazonEnabled');
+        hasAmazonEnabled = hasAmazonEnabled || utils.deepAccess(matchObj.transactionObject, 'hbSource.values.amazonEnabled');
       });
       setTargeting(adUnitCodes, mappings);
       if (hasAmazonEnabled) {

--- a/modules/ppi/hbDestination/gptDestination.js
+++ b/modules/ppi/hbDestination/gptDestination.js
@@ -1,4 +1,3 @@
-import Set from 'core-js-pure/features/set';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import * as utils from '../../../src/utils.js';
 import { setTargeting as setAmazonTargeting } from '../../ppi/hbSource/amazonSource.js';
@@ -111,12 +110,12 @@ function validateExistingSlot(gptSlot, adUnitPath, adUnitSizes, divId) {
   adUnitSizes = adUnitSizes.map(size => `${size[0]}x${size[1]}`);
 
   let hasDifference = (listA, listB) => {
-    let diff = new Set(listA)
+    let diff = new Set(listA);
     for (let elem of listB) {
-      diff.delete(elem)
+      diff.delete(elem);
     }
     return diff.size;
-  }
+  };
 
   if (hasDifference(gptSlotSizes, adUnitSizes) || hasDifference(adUnitSizes, gptSlotSizes)) {
     utils.logWarn(`[PPI] target div '${divId}' contains slot that has different sizes than pbjs Ad Unit. Slot sizes: [${gptSlotSizes}], pbjs Ad Unit sizes: [${adUnitSizes}]. Check your pbjs Ad Unit configuration and gpt slot definition.`);
@@ -143,7 +142,7 @@ function setTargeting(adUnitCodes, mappings) {
     let id = slot.getSlotElementId();
     return (adUnitCode) => {
       return mappings[adUnitCode] === id;
-    }
+    };
   });
 }
 

--- a/modules/ppi/hbInventory/aup/aup.js
+++ b/modules/ppi/hbInventory/aup/aup.js
@@ -433,9 +433,7 @@ export function transformAutoSlots(transactionObject) {
         },
         ortb2Imp: transactionObject.hbInventory.ortb2Imp,
       },
-      hbSource: {
-        type: transactionObject.hbSource.type,
-      },
+      hbSource: transactionObject.hbSource,
       hbDestination: transactionObject.hbDestination,
     };
 

--- a/modules/ppi/hbInventory/aup/sizes.js
+++ b/modules/ppi/hbInventory/aup/sizes.js
@@ -1,6 +1,5 @@
 import * as utils from '../../../../src/utils.js';
 import { TransactionType } from './consts.js';
-import find from 'core-js-pure/features/array/find.js';
 
 /**
  * Find sizes for given adUnitPattern
@@ -31,7 +30,7 @@ export function findLimitSizes(transactionObject) {
   if (transactionObject.hbInventory.type === TransactionType.SLOT_OBJECT) {
     let gptSizes = getGptSlotSizes(transactionObject.hbInventory.values.slot);
     if (!toSizes || !toSizes.length) {
-      return gptSizes
+      return gptSizes;
     }
 
     utils.logWarn(`slot defined with sizes: ${gptSizes}. Using sizes override: ${toSizes}`);
@@ -88,11 +87,11 @@ function filterResponsiveSizes(sizeConfig, viewport) {
   try {
     // sort sizeConfig from biggest to smallest viewport
     // then find the biggest one that fits in the given viewport
-    let val = (find(sizeConfig.sort((a, b) => {
+    let val = (sizeConfig.sort((a, b) => {
       let aVP = a.minViewPort;
       let bVP = b.minViewPort;
       return bVP[0] * bVP[1] - aVP[0] * aVP[1] || bVP[0] - aVP[0] || bVP[1] - aVP[1];
-    }), (responsiveSize) => {
+    }).find((responsiveSize) => {
       return viewport[0] >= responsiveSize.minViewPort[0] && viewport[1] >= responsiveSize.minViewPort[1];
     }));
     sizes = val && val.sizes;

--- a/modules/ppi/hbSource/amazonSource.js
+++ b/modules/ppi/hbSource/amazonSource.js
@@ -1,0 +1,55 @@
+import { deepAccess, isFn, logError, logInfo, logWarn } from '../../../src/utils.js';
+import { getDivIdGPTSlotMapping } from '../hbDestination/gptDestination.js';
+
+const APSTAG_TIMEOUT = 5000;
+
+export function fetchBids(matchObjects, callback) {
+  if (!isFn(deepAccess(window, 'apstag.fetchBids'))) {
+    logError(`apstag.js library is not loaded on the page. Please load and initialize the library before calling amazon to fetch bids. Continuing without amazon bids`);
+    return callback();
+  }
+
+  let slots = createAmazonSlots(matchObjects);
+  let callbackExecuted = false;
+
+  let timeoutId = setTimeout(() => {
+    if (!callbackExecuted) {
+      logError(`Didn't receive response from apstag for ${APSTAG_TIMEOUT} ms. Continuing without amazon bids.`);
+      callbackExecuted = true;
+      callback();
+    }
+  }, APSTAG_TIMEOUT);
+  window.apstag.fetchBids({ slots }, (bids) => {
+    if (callbackExecuted) {
+      logWarn(`Callback was already executed, bids arrived too late. Continuing without amazon bids`);
+      return;
+    }
+    logInfo(`Received amazon bids: `, bids);
+    callbackExecuted = true;
+    clearTimeout(timeoutId);
+    callback();
+  });
+}
+
+export function createAmazonSlots(matchObjects) {
+  let mappings = getDivIdGPTSlotMapping();
+  return matchObjects.map(matchObject => {
+    let slotID = matchObject.transactionObject.hbDestination.values.div || matchObject.transactionObject.divId;
+    let slotName = matchObject.transactionObject.slotName;
+    if (!slotName) {
+      let slot = mappings[slotID];
+      if (slot) {
+        slotName = slot.getAdUnitPath();
+      }
+    }
+    return {
+      slotID,
+      slotName,
+      sizes: deepAccess(matchObject.adUnit, 'mediaTypes.banner.sizes'),
+    }
+  });
+}
+
+export function setTargeting() {
+  window.apstag.setDisplayBids();
+}

--- a/modules/ppi/hbSource/amazonSource.js
+++ b/modules/ppi/hbSource/amazonSource.js
@@ -3,14 +3,14 @@ import { config } from '../../../src/config.js';
 
 export function fetchBids(matchObjects, callback) {
   if (!isFn(deepAccess(window, 'apstag.fetchBids'))) {
-    logError(`apstag.js library is not loaded on the page. Please load and initialize the library before calling amazon to fetch bids. Continuing without amazon bids.`);
+    logError(`[PPI] apstag.js library is not loaded on the page. Please load and initialize the library before calling amazon to fetch bids. Continuing without amazon bids.`);
     callback();
     return;
   }
 
   let slots = createAmazonSlots(matchObjects);
   if (!slots.length) {
-    logWarn(`Couldn't create amazon slots to fetch bids. Continuing without amazon bids.`)
+    logWarn(`[PPI] Couldn't create amazon slots to fetch bids. Continuing without amazon bids.`)
     callback();
     return;
   }
@@ -20,16 +20,16 @@ export function fetchBids(matchObjects, callback) {
   let apstagTimeout = config.getConfig('bidderTimeout');
 
   let timeoutId = setTimeout(() => {
-    logError(`Didn't receive response from apstag for ${apstagTimeout} ms. Continuing without amazon bids.`);
+    logError(`[PPI] Didn't receive response from apstag for ${apstagTimeout} ms. Continuing without amazon bids.`);
     callbackExecuted = true;
     callback();
   }, apstagTimeout);
   window.apstag.fetchBids({ slots }, (bids) => {
     if (callbackExecuted) {
-      logWarn(`Callback was already executed, bids arrived too late. Continuing without amazon bids.`);
+      logWarn(`[PPI] Callback was already executed, bids arrived too late. Continuing without amazon bids.`);
       return;
     }
-    logInfo(`Received amazon bids: `, bids);
+    logInfo(`[PPI] Received amazon bids: `, bids);
     callbackExecuted = true;
     clearTimeout(timeoutId);
     callback();
@@ -57,7 +57,7 @@ export function createAmazonSlots(matchObjects) {
     }
 
     if (!slotID || !slotName) {
-      logWarn(`Couldn't find div id (${slotID}) or slot name (${slotName}), will not request bids from amazon for this transaction object`);
+      logWarn(`[PPI] Couldn't find div id (${slotID}) or slot name (${slotName}), will not request bids from amazon for this transaction object`);
       return;
     }
 

--- a/modules/ppi/hbSource/auctionSource.js
+++ b/modules/ppi/hbSource/auctionSource.js
@@ -3,6 +3,7 @@ import { getGlobal } from '../../../src/prebidGlobal.js';
 import { filters } from '../../../src/targeting.js';
 import { config } from '../../../src/config.js';
 import { auctionTracker } from './auctionTracker.js';
+import { fetchBids } from './amazonSource.js';
 
 /** @type {Submodule}
  * Responsibility of this submodule is to provide mechanism for ppi to requestBids from new HB auction
@@ -18,6 +19,23 @@ export const auctionSourceSubmodule = {
    */
   requestBids({ matchObjects, requestBidsParameters, callback }) {
     utils.logInfo('[PPI] Triggering new HB auction');
+    let pbjsExecuted = false;
+    let amazonExecuted = true;
+
+    const wrappedCallback = () => {
+      if (pbjsExecuted && amazonExecuted && utils.isFn(callback)) {
+        callback(matchObjects);
+      }
+    }
+
+    let matchesWithAmazon = matchObjects.filter(matchObject => utils.deepAccess(matchObject.transactionObject, 'hbSource.amazonEnabled'));
+    if (matchesWithAmazon.length) {
+      amazonExecuted = false;
+      fetchBids(matchesWithAmazon, () => {
+        amazonExecuted = true;
+        wrappedCallback();
+      });
+    }
 
     let pbjs = getGlobal();
     pbjs.requestBids({
@@ -49,9 +67,8 @@ export const auctionSourceSubmodule = {
           };
         });
 
-        if (utils.isFn(callback)) {
-          callback(matchObjects);
-        }
+        pbjsExecuted = true;
+        wrappedCallback();
       }
     });
   },

--- a/modules/ppi/hbSource/auctionSource.js
+++ b/modules/ppi/hbSource/auctionSource.js
@@ -28,7 +28,7 @@ export const auctionSourceSubmodule = {
       }
     }
 
-    let matchesWithAmazon = matchObjects.filter(matchObject => utils.deepAccess(matchObject.transactionObject, 'hbSource.amazonEnabled'));
+    let matchesWithAmazon = matchObjects.filter(matchObject => utils.deepAccess(matchObject.transactionObject, 'hbSource.values.amazonEnabled'));
     if (matchesWithAmazon.length) {
       amazonExecuted = false;
       fetchBids(matchesWithAmazon, () => {

--- a/modules/ppi/hbSource/cacheSource.js
+++ b/modules/ppi/hbSource/cacheSource.js
@@ -37,9 +37,9 @@ export const cacheSourceSubmodule = {
         if (cachedMatchesReady && auctionExecuted) {
           callback(emptyCacheMatches.concat(readyMatches));
         } else if (!auctionExecuted) {
-          callback(emptyCacheMatches);
+          callback(readyMatches);
           // empty this array so that later '.concat' won't duplicate refreshes for some slots
-          emptyCacheMatches = [];
+          readyMatches = [];
         }
       }
     }
@@ -87,8 +87,8 @@ export const cacheSourceSubmodule = {
       readyMatches.push(matchObj);
     });
 
-    if (readyMatches.length && utils.isFn(callback)) {
-      cachedMatchesReady = true;
+    cachedMatchesReady = true;
+    if (readyMatches.length) {
       wrappedCallback();
     }
 
@@ -112,10 +112,8 @@ export const cacheSourceSubmodule = {
             };
           });
 
-          if (utils.isFn(callback)) {
-            auctionExecuted = true;
-            wrappedCallback();
-          }
+          auctionExecuted = true;
+          wrappedCallback();
         }
       });
     }

--- a/modules/ppi/hbSource/cacheSource.js
+++ b/modules/ppi/hbSource/cacheSource.js
@@ -44,9 +44,9 @@ export const cacheSourceSubmodule = {
       }
     }
 
-    let matchesWithAmazon = matchObjects.filter(matchObject => utils.deepAccess(matchObject.transactionObject, 'hbSource.amazonEnabled'));
+    let matchesWithAmazon = matchObjects.filter(matchObject => utils.deepAccess(matchObject.transactionObject, 'hbSource.values.amazonEnabled'));
     if (matchesWithAmazon.length) {
-      utils.logWarn(`Amazon is enabled for some transaction objects. Fetching amazon bids before refreshing actual slots`);
+      utils.logWarn(`[PPI] Amazon is enabled for some transaction objects. Fetching amazon bids before refreshing actual slots`);
       amazonExecuted = false;
       fetchBids(matchesWithAmazon, () => {
         amazonExecuted = true;

--- a/modules/ppi/index.js
+++ b/modules/ppi/index.js
@@ -1,4 +1,3 @@
-import Set from 'core-js-pure/features/set';
 import * as utils from '../../src/utils.js';
 import { getGlobal } from '../../src/prebidGlobal.js';
 import { hbSource } from './hbSource/hbSource.js';
@@ -97,7 +96,7 @@ export function validateTransactionObjects(transactionObjects) {
     }
 
     if (!validDestinationTypes.has(to.hbDestination.type)) {
-      to.error = `destination type ${to.hbDestination.type} not supported`
+      to.error = `destination type ${to.hbDestination.type} not supported`;
       invalid.push(to);
       return;
     }
@@ -124,7 +123,7 @@ export function validateTransactionObjects(transactionObjects) {
       let isSizeValid = (size) => {
         return (Array.isArray(size) && size.length === 2 && typeof (size[0]) === 'number' && typeof (size[1]) === 'number') ||
           size === 'fluid';
-      }
+      };
 
       to.hbInventory.sizes = to.hbInventory.sizes.filter(s => {
         if (!isSizeValid(s)) {
@@ -147,7 +146,7 @@ export function validateTransactionObjects(transactionObjects) {
   return {
     valid,
     invalid,
-  }
+  };
 }
 
 /**

--- a/modules/ppi/index.js
+++ b/modules/ppi/index.js
@@ -136,6 +136,11 @@ export function validateTransactionObjects(transactionObjects) {
       });
     }
 
+    if (to.hbSource.amazonEnabled && to.hbDestination.type !== 'gpt') {
+      utils.logWarn(`Amazon bids are enabled only for 'gpt' destination. Disabling amazon for transaction object: `, to);
+      to.hbSource.amazonEnabled = false;
+    }
+
     valid.push(to);
   });
 

--- a/modules/ppi/index.js
+++ b/modules/ppi/index.js
@@ -136,9 +136,9 @@ export function validateTransactionObjects(transactionObjects) {
       });
     }
 
-    if (to.hbSource.amazonEnabled && to.hbDestination.type !== 'gpt') {
-      utils.logWarn(`Amazon bids are enabled only for 'gpt' destination. Disabling amazon for transaction object: `, to);
-      to.hbSource.amazonEnabled = false;
+    if (to.hbSource.values && to.hbSource.values.amazonEnabled && to.hbDestination.type !== 'gpt') {
+      utils.logWarn(`[PPI] Amazon bids are enabled only for 'gpt' destination. Disabling amazon for transaction object: `, to);
+      to.hbSource.values.amazonEnabled = false;
     }
 
     valid.push(to);

--- a/test/spec/integration/faker/googletag.js
+++ b/test/spec/integration/faker/googletag.js
@@ -31,6 +31,9 @@ var Slot = function Slot({ code, divId }) {
 
     clearTargeting: function clearTargeting() {
       return window.googletag.pubads().getSlots();
+    },
+    updateTargetingFromMap: function updateTargetingFromMap(targetingMap) {
+      Object.keys(targetingMap).forEach(key => this.setTargeting(key, targetingMap[key]));
     }
   };
   slot.spySetTargeting = sinon.spy(slot, 'setTargeting');
@@ -44,7 +47,7 @@ export function makeSlot() {
 }
 
 export function emitEvent(eventName, params) {
-  (window.googletag._callbackMap[eventName] || []).forEach(eventCb => eventCb({...params, eventName}));
+  (window.googletag._callbackMap[eventName] || []).forEach(eventCb => eventCb({ ...params, eventName }));
 }
 
 export function enable() {
@@ -68,19 +71,19 @@ export function enable() {
           self._slots = slots;
         },
 
-        setTargeting: function(key, arrayOfValues) {
+        setTargeting: function (key, arrayOfValues) {
           self._targeting[key] = Array.isArray(arrayOfValues) ? arrayOfValues : [arrayOfValues];
         },
 
-        getTargeting: function(key) {
+        getTargeting: function (key) {
           return self._targeting[key] || [];
         },
 
-        getTargetingKeys: function() {
+        getTargetingKeys: function () {
           return Object.getOwnPropertyNames(self._targeting);
         },
 
-        clearTargeting: function() {
+        clearTargeting: function () {
           self._targeting = {};
         },
 

--- a/test/spec/modules/hbSource_spec.js
+++ b/test/spec/modules/hbSource_spec.js
@@ -391,7 +391,7 @@ describe('test ppi amazon support', () => {
       bidsBackHandler();
     });
 
-    let matches = [{ adUnit: { code: 'test-unit' }, transactionObject: { divId: 'test-div', hbSource: { amazonEnabled: true } } }];
+    let matches = [{ adUnit: { code: 'test-unit' }, transactionObject: { divId: 'test-div', hbSource: { values: { amazonEnabled: true } } } }];
     hbSource['auction'].requestBids(matches, () => {
       bidsRequested = true;
     });

--- a/test/spec/modules/hbSource_spec.js
+++ b/test/spec/modules/hbSource_spec.js
@@ -385,15 +385,19 @@ describe('test ppi amazon support', () => {
   });
 
   it('should call amazon and pbjs at the same time', () => {
+    makeSlot({ code: 'test-unit', divId: 'test-div' });
     attachApstag();
     let bidsRequested = false;
-    sandbox.stub($$PREBID_GLOBAL$$, 'requestBids').callsFake(({ bidsBackHandler }) => {
+    sandbox.stub(prebid, 'requestBids').callsFake(({ bidsBackHandler }) => {
       bidsBackHandler();
     });
 
     let matches = [{ adUnit: { code: 'test-unit' }, transactionObject: { divId: 'test-div', hbSource: { values: { amazonEnabled: true } } } }];
-    hbSource['auction'].requestBids(matches, () => {
-      bidsRequested = true;
+    hbSource['auction'].requestBids({
+      matchObjects: matches,
+      callback: () => {
+        bidsRequested = true;
+      }
     });
 
     expect(bidsRequested).to.equal(true);


### PR DESCRIPTION
Add possibility to fetch amazon bids in ppi from `apstag.js` library.  
PPI will request bids only for the following transaction objects:
- needs to have destination set to `gpt`
- needs to have `amazonEnabled: true` property on `hbSource` object

When PPI requests pbjs to hold an auction, at the same time it will request bids from amazon. Only after both callbacks are done it will refresh gpt slots.

Unlike for prebid bids, ppi doesn't support caching amazon bids, so each time request is made for ppi to refresh slots from cache it will request amazon bids.