### PR TITLE
Hb 14366

### DIFF
--- a/modules/ppi/hbSource/cacheSource.js
+++ b/modules/ppi/hbSource/cacheSource.js
@@ -42,8 +42,7 @@ export const cacheSourceSubmodule = {
 
       let bids = responses.bids
         .filter(filters.isUnusedBid)
-        .filter(filters.isBidNotExpired)
-        .filter(bid => bid.cpm > 0);
+        .filter(filters.isBidNotExpired);
 
       if (!bids || !bids.length) {
         utils.logInfo(`[PPI] - did not find any bid for ${matchObj.adUnit.code}, queuing it for new HB auction`);

--- a/test/spec/modules/ppi_spec.js
+++ b/test/spec/modules/ppi_spec.js
@@ -311,4 +311,5 @@ describe('ppiTest', () => {
       expect(res[0].adUnit.ortb2Imp.ext.data.elementid).to.equal('test-1');
       expect(res[2].adUnit.ortb2Imp.ext.data.elementid).to.equal('test-5');
     });
+  });
 });


### PR DESCRIPTION
https://jira.magnite-core.com/browse/HB-14366 

Only cacheSource was messing up with cpm; the standard behaviour of prebid is preserved. 